### PR TITLE
Replace Flask app with Node.js React version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+responses.json
+survey.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# survey
+# Survey Web App
+
+A simple Node.js and React-based application for collecting event feedback. Tailwind CSS is used for styling. Questions are configurable via `questions.json`. Admins can log in to view all submissions.
+
+## Features
+
+- **Survey Form**: Participants answer questions defined in `questions.json`.
+- **Admin Login**: Admin credentials set via environment variables `ADMIN_USERNAME` and `ADMIN_PASSWORD`.
+- **Results View**: After logging in, admins can see all responses in a table.
+
+## Requirements
+
+- Node.js 14+
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install express express-session
+   ```
+2. Start the server:
+   ```bash
+   node server.js
+   ```
+3. Open `http://localhost:5000` in your browser for the survey form. Visit `http://localhost:5000/admin.html` for the admin page.
+
+The default admin username and password are both `admin`/`password`. Change them before deploying.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "survey-app",
+  "version": "1.0.0",
+  "main": "server.js",
+  "license": "MIT",
+  "dependencies": {
+    "express": "^4.18.0",
+    "express-session": "^1.17.3"
+  }
+}

--- a/public/admin.html
+++ b/public/admin.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Admin</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/react@17/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body class="p-6">
+  <div id="root"></div>
+
+  <script type="text/babel">
+    function AdminApp() {
+      const [loggedIn, setLoggedIn] = React.useState(false);
+      const [form, setForm] = React.useState({ username: '', password: '' });
+      const [responses, setResponses] = React.useState([]);
+
+      const handleChange = (e) => {
+        setForm({ ...form, [e.target.name]: e.target.value });
+      };
+
+      const login = (e) => {
+        e.preventDefault();
+        fetch('/api/admin/login', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(form)
+        })
+          .then(res => {
+            if (res.ok) {
+              setLoggedIn(true);
+              loadResponses();
+            } else {
+              alert('Login failed');
+            }
+          });
+      };
+
+      const loadResponses = () => {
+        fetch('/api/admin/responses')
+          .then(res => res.json())
+          .then(setResponses);
+      };
+
+      const logout = () => {
+        fetch('/api/admin/logout')
+          .then(() => {
+            setLoggedIn(false);
+            setResponses([]);
+          });
+      };
+
+      if (!loggedIn) {
+        return (
+          <form onSubmit={login} className="space-y-4 max-w-sm">
+            <div>
+              <label className="block mb-1 font-semibold">Username</label>
+              <input name="username" className="w-full p-2 border rounded" onChange={handleChange} required />
+            </div>
+            <div>
+              <label className="block mb-1 font-semibold">Password</label>
+              <input type="password" name="password" className="w-full p-2 border rounded" onChange={handleChange} required />
+            </div>
+            <button className="px-4 py-2 bg-blue-500 text-white rounded" type="submit">Login</button>
+          </form>
+        );
+      }
+
+      return (
+        <div className="space-y-4">
+          <button className="px-4 py-2 bg-gray-300 rounded" onClick={logout}>Logout</button>
+          <table className="table-auto border-collapse border w-full">
+            <thead>
+              <tr>
+                <th className="border px-2">Timestamp</th>
+                {responses.length > 0 && Object.keys(responses[0]).filter(k => k !== 'timestamp').map(key => (
+                  <th key={key} className="border px-2">{key}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {responses.map((r, idx) => (
+                <tr key={idx}>
+                  <td className="border px-2">{r.timestamp}</td>
+                  {Object.entries(r).filter(([k]) => k !== 'timestamp').map(([k, v]) => (
+                    <td key={k} className="border px-2">{v}</td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
+    }
+
+    ReactDOM.render(<AdminApp />, document.getElementById('root'));
+  </script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Event Survey</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/react@17/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body class="p-6">
+  <div id="root"></div>
+
+  <script type="text/babel">
+    function Survey() {
+      const [questions, setQuestions] = React.useState([]);
+      const [formData, setFormData] = React.useState({});
+      const [submitted, setSubmitted] = React.useState(false);
+
+      React.useEffect(() => {
+        fetch('/api/questions')
+          .then(res => res.json())
+          .then(setQuestions);
+      }, []);
+
+      const handleChange = (id, value) => {
+        setFormData({ ...formData, [id]: value });
+      };
+
+      const handleSubmit = (e) => {
+        e.preventDefault();
+        fetch('/api/response', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(formData)
+        }).then(() => setSubmitted(true));
+      };
+
+      if (submitted) {
+        return <div className="text-xl">Thanks for your response!</div>;
+      }
+
+      return (
+        <form onSubmit={handleSubmit} className="space-y-4 max-w-xl">
+          {questions.map(q => (
+            <div key={q.id}>
+              <label className="block mb-1 font-semibold">{q.text}</label>
+              <input
+                className="w-full p-2 border rounded"
+                onChange={e => handleChange(q.id, e.target.value)}
+                required
+              />
+            </div>
+          ))}
+          <button className="px-4 py-2 bg-blue-500 text-white rounded" type="submit">Submit</button>
+        </form>
+      );
+    }
+
+    ReactDOM.render(<Survey />, document.getElementById('root'));
+  </script>
+</body>
+</html>

--- a/questions.json
+++ b/questions.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "q1",
+    "text": "How satisfied were you with the event?"
+  },
+  {
+    "id": "q2",
+    "text": "What could be improved?"
+  }
+]

--- a/server.js
+++ b/server.js
@@ -1,0 +1,77 @@
+const express = require('express');
+const session = require('express-session');
+const fs = require('fs');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 5000;
+const ADMIN_USERNAME = process.env.ADMIN_USERNAME || 'admin';
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'password';
+
+const QUESTIONS_FILE = path.join(__dirname, 'questions.json');
+const RESPONSES_FILE = path.join(__dirname, 'responses.json');
+
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+app.use(session({
+  secret: 'change-me',
+  resave: false,
+  saveUninitialized: false
+}));
+
+app.use(express.static('public'));
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (err) {
+    return [];
+  }
+}
+
+function writeJson(filePath, data) {
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+}
+
+app.get('/api/questions', (req, res) => {
+  const questions = readJson(QUESTIONS_FILE);
+  res.json(questions);
+});
+
+app.post('/api/response', (req, res) => {
+  const responses = readJson(RESPONSES_FILE);
+  responses.push({
+    ...req.body,
+    timestamp: new Date().toISOString()
+  });
+  writeJson(RESPONSES_FILE, responses);
+  res.json({ success: true });
+});
+
+app.post('/api/admin/login', (req, res) => {
+  const { username, password } = req.body;
+  if (username === ADMIN_USERNAME && password === ADMIN_PASSWORD) {
+    req.session.admin = true;
+    res.json({ success: true });
+  } else {
+    res.status(401).json({ success: false });
+  }
+});
+
+app.get('/api/admin/responses', (req, res) => {
+  if (!req.session.admin) {
+    return res.status(401).json({ error: 'unauthorized' });
+  }
+  const responses = readJson(RESPONSES_FILE);
+  res.json(responses);
+});
+
+app.get('/api/admin/logout', (req, res) => {
+  req.session.destroy(() => {
+    res.json({ success: true });
+  });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- reimplement survey app using Node.js, Express, and React
- provide Tailwind-styled survey and admin pages
- store questions in `questions.json` and responses in `responses.json`
- update README with new setup instructions

## Testing
- `npm install --silent`
- `node server.js` *(server started)*

------
https://chatgpt.com/codex/tasks/task_b_6865336ad5988332812f83753490aeec