### PR TITLE
Implement endpoint for admin question addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This project collects event feedback using a simple REST API and a React front-e
 
 - **Survey Form** – questions are defined in `questions.json` and submissions are stored in `responses.json`.
 - **Admin Login** – environment variables `ADMIN_USERNAME` and `ADMIN_PASSWORD` control access.
+- **Add Questions** – authenticated admins can append new single-choice questions with `PUT /api/questions`.
 - **Results View** – logged-in admins can see all responses.
 - **Survey Management** – admins can create new surveys via the API backed by MongoDB.
 

--- a/client/src/Survey.tsx
+++ b/client/src/Survey.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 interface Question {
   id: string;
   text: string;
+  options: string[];
 }
 
 const Survey: React.FC = () => {
@@ -39,11 +40,19 @@ const Survey: React.FC = () => {
       {questions.map((q) => (
         <div key={q.id}>
           <label className="block mb-1 font-semibold">{q.text}</label>
-          <input
-            className="w-full p-2 border rounded"
-            onChange={(e) => handleChange(q.id, e.target.value)}
-            required
-          />
+          {q.options.map((opt) => (
+            <label key={opt} className="block">
+              <input
+                type="radio"
+                name={q.id}
+                className="mr-2"
+                value={opt}
+                onChange={() => handleChange(q.id, opt)}
+                required
+              />
+              {opt}
+            </label>
+          ))}
         </div>
       ))}
       <button className="px-4 py-2 bg-blue-500 text-white rounded" type="submit">

--- a/questions.json
+++ b/questions.json
@@ -1,10 +1,12 @@
 [
   {
     "id": "q1",
-    "text": "How satisfied were you with the event?"
+    "text": "How satisfied were you with the event?",
+    "options": ["Very satisfied", "Satisfied", "Neutral", "Dissatisfied"]
   },
   {
     "id": "q2",
-    "text": "What could be improved?"
+    "text": "What could be improved?",
+    "options": ["Nothing", "Schedule", "Venue", "Other"]
   }
 ]

--- a/server.js
+++ b/server.js
@@ -55,6 +55,22 @@ app.get('/api/questions', (req, res) => {
   res.json(questions);
 });
 
+app.put('/api/questions', (req, res) => {
+  if (!req.session.admin) {
+    return res.status(401).json({ error: 'unauthorized' });
+  }
+  const { text, options } = req.body;
+  if (typeof text !== 'string' || !Array.isArray(options) || !options.every((o) => typeof o === 'string')) {
+    return res.status(400).json({ error: 'invalid data' });
+  }
+  const questions = readJson(QUESTIONS_FILE);
+  const id = 'q' + (questions.length + 1);
+  const newQuestion = { id, text, options };
+  questions.push(newQuestion);
+  writeJson(QUESTIONS_FILE, questions);
+  res.json(newQuestion);
+});
+
 app.post('/api/response', (req, res) => {
   const responses = readJson(RESPONSES_FILE);
   responses.push({


### PR DESCRIPTION
## Summary
- allow admins to append questions through `PUT /api/questions`
- render survey questions as single-choice radio groups
- add example options to `questions.json`
- document question addition endpoint in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68653c9eddf48332a0373ab7f98f13ed