### PR TITLE
Add admin survey statistics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This project collects event feedback using a simple REST API and a React front-e
 - **Add Questions** – authenticated admins can append new single-choice questions with `PUT /api/questions`.
 - **Results View** – logged-in admins can see all responses.
 - **Survey Management** – admins can create new surveys via the API backed by MongoDB.
+- **View Statistics** – `GET /api/admin/surveys/:id/statistics` returns option counts for each question.
 
 ## Backend Structure
 


### PR DESCRIPTION
## Summary
- allow admins to fetch statistics for a survey
- document the new endpoint in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68653feb4ee483328ea47a0876ba2b63