### PR TITLE
Refactor survey response handling

### DIFF
--- a/controllers/surveyController.js
+++ b/controllers/surveyController.js
@@ -1,0 +1,14 @@
+const { surveyResponseSchema } = require('../schemas/surveySchemas');
+const { saveSurveyResponse } = require('../services/surveyService');
+
+async function submitSurveyResponse(req, res) {
+  try {
+    const data = surveyResponseSchema.parse({ ...req.body, surveyId: req.params.surveyId });
+    const saved = await saveSurveyResponse(data);
+    res.json({ success: true, data: saved });
+  } catch (err) {
+    res.status(400).json({ success: false, error: 'invalid data' });
+  }
+}
+
+module.exports = { submitSurveyResponse };

--- a/controllers/surveyController.ts
+++ b/controllers/surveyController.ts
@@ -1,0 +1,13 @@
+import { Request, Response } from 'express';
+import { surveyResponseSchema } from '../schemas/surveySchemas';
+import { saveSurveyResponse } from '../services/surveyService';
+
+export async function submitSurveyResponse(req: Request, res: Response) {
+  try {
+    const data = surveyResponseSchema.parse({ ...req.body, surveyId: req.params.surveyId });
+    const saved = await saveSurveyResponse(data);
+    res.json({ success: true, data: saved });
+  } catch (err) {
+    res.status(400).json({ success: false, error: 'invalid data' });
+  }
+}

--- a/routes/responses.js
+++ b/routes/responses.js
@@ -1,8 +1,7 @@
 const express = require('express');
 const path = require('path');
 const { readJson, writeJson } = require('../utils/file');
-const Response = require('../models/Response');
-const { surveyResponseSchema } = require('../shared/surveyResponse');
+const { submitSurveyResponse } = require('../controllers/surveyController');
 
 const router = express.Router();
 const RESPONSES_FILE = path.join(__dirname, '..', 'responses.json');
@@ -17,15 +16,6 @@ router.post('/response', (req, res) => {
   res.json({ success: true });
 });
 
-router.post('/surveys/:surveyId/responses', async (req, res) => {
-  const { surveyId } = req.params;
-  try {
-    const data = surveyResponseSchema.parse({ ...req.body, surveyId });
-    const response = await Response.create(data);
-    res.json(response);
-  } catch (err) {
-    res.status(400).json({ error: 'invalid data' });
-  }
-});
+router.post('/surveys/:surveyId/responses', submitSurveyResponse);
 
 module.exports = router;

--- a/schemas/surveySchemas.js
+++ b/schemas/surveySchemas.js
@@ -1,0 +1,8 @@
+const zod_1 = require('zod');
+
+exports.surveyResponseSchema = zod_1.z.object({
+  name: zod_1.z.string(),
+  email: zod_1.z.string().email(),
+  surveyId: zod_1.z.string().regex(/^[0-9a-fA-F]{24}$/),
+  answers: zod_1.z.array(zod_1.z.string()),
+});

--- a/schemas/surveySchemas.ts
+++ b/schemas/surveySchemas.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const surveyResponseSchema = z.object({
+  name: z.string(),
+  email: z.string().email(),
+  surveyId: z.string().regex(/^[0-9a-fA-F]{24}$/),
+  answers: z.array(z.string()),
+});
+
+export type SurveyResponse = z.infer<typeof surveyResponseSchema>;

--- a/services/surveyService.js
+++ b/services/surveyService.js
@@ -1,0 +1,8 @@
+const ResponseModel = require('../models/Response');
+
+async function saveSurveyResponse(data) {
+  const response = await ResponseModel.create(data);
+  return response.toObject();
+}
+
+module.exports = { saveSurveyResponse };

--- a/services/surveyService.ts
+++ b/services/surveyService.ts
@@ -1,0 +1,7 @@
+import ResponseModel from '../models/Response';
+import { SurveyResponse } from '../schemas/surveySchemas';
+
+export async function saveSurveyResponse(data: SurveyResponse) {
+  const response = await ResponseModel.create(data);
+  return response.toObject();
+}


### PR DESCRIPTION
## Summary
- split survey submission into controller, service and schema
- update response route to use the controller
- add TypeScript definitions alongside CommonJS versions

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_b_6868ab9531cc833286104c8c9833602e