### PR TITLE
Add unified Express error handling

### DIFF
--- a/controllers/surveyController.js
+++ b/controllers/surveyController.js
@@ -2,13 +2,9 @@ const { surveyResponseSchema } = require('../schemas/surveySchemas');
 const { saveSurveyResponse } = require('../services/surveyService');
 
 async function submitSurveyResponse(req, res) {
-  try {
-    const data = surveyResponseSchema.parse({ ...req.body, surveyId: req.params.surveyId });
-    const saved = await saveSurveyResponse(data);
-    res.json({ success: true, data: saved });
-  } catch (err) {
-    res.status(400).json({ success: false, error: 'invalid data' });
-  }
+  const data = surveyResponseSchema.parse({ ...req.body, surveyId: req.params.surveyId });
+  const saved = await saveSurveyResponse(data);
+  res.json({ success: true, data: saved });
 }
 
 module.exports = { submitSurveyResponse };

--- a/controllers/surveyController.ts
+++ b/controllers/surveyController.ts
@@ -3,11 +3,7 @@ import { surveyResponseSchema } from '../schemas/surveySchemas';
 import { saveSurveyResponse } from '../services/surveyService';
 
 export async function submitSurveyResponse(req: Request, res: Response) {
-  try {
-    const data = surveyResponseSchema.parse({ ...req.body, surveyId: req.params.surveyId });
-    const saved = await saveSurveyResponse(data);
-    res.json({ success: true, data: saved });
-  } catch (err) {
-    res.status(400).json({ success: false, error: 'invalid data' });
-  }
+  const data = surveyResponseSchema.parse({ ...req.body, surveyId: req.params.surveyId });
+  const saved = await saveSurveyResponse(data);
+  res.json({ success: true, data: saved });
 }

--- a/middlewares/asyncHandler.js
+++ b/middlewares/asyncHandler.js
@@ -1,0 +1,7 @@
+function asyncHandler(fn) {
+  return function (req, res, next) {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}
+
+module.exports = asyncHandler;

--- a/middlewares/errorHandler.js
+++ b/middlewares/errorHandler.js
@@ -1,0 +1,22 @@
+const { ZodError } = require('zod');
+
+function errorHandler(err, req, res, next) {
+  // Default values
+  let status = 500;
+  let message = 'Internal server error';
+
+  if (err instanceof ZodError) {
+    status = 400;
+    message = err.errors.map(e => e.message).join(', ');
+  } else if (err.statusCode) {
+    status = err.statusCode;
+    message = err.message || message;
+  } else if (err.message) {
+    status = 400;
+    message = err.message;
+  }
+
+  res.status(status).json({ success: false, message, statusCode: status });
+}
+
+module.exports = errorHandler;

--- a/routes/responses.js
+++ b/routes/responses.js
@@ -2,6 +2,7 @@ const express = require('express');
 const path = require('path');
 const { readJson, writeJson } = require('../utils/file');
 const { submitSurveyResponse } = require('../controllers/surveyController');
+const asyncHandler = require('../middlewares/asyncHandler');
 
 const router = express.Router();
 const RESPONSES_FILE = path.join(__dirname, '..', 'responses.json');
@@ -16,6 +17,6 @@ router.post('/response', (req, res) => {
   res.json({ success: true });
 });
 
-router.post('/surveys/:surveyId/responses', submitSurveyResponse);
+router.post('/surveys/:surveyId/responses', asyncHandler(submitSurveyResponse));
 
 module.exports = router;

--- a/routes/surveys.js
+++ b/routes/surveys.js
@@ -1,23 +1,21 @@
 const express = require('express');
 const Survey = require('../models/Survey');
+const asyncHandler = require('../middlewares/asyncHandler');
+const AppError = require('../utils/AppError');
 
 const router = express.Router();
 
 // Public list of all surveys
-router.get('/surveys', async (req, res) => {
+router.get('/surveys', asyncHandler(async (req, res) => {
   const surveys = await Survey.find().lean();
   res.json(surveys);
-});
+}));
 
 // Fetch a single survey by id
-router.get('/surveys/:id', async (req, res) => {
-  try {
-    const survey = await Survey.findById(req.params.id).lean();
-    if (!survey) return res.status(404).json({ error: 'not found' });
-    res.json(survey);
-  } catch (err) {
-    res.status(400).json({ error: 'invalid id' });
-  }
-});
+router.get('/surveys/:id', asyncHandler(async (req, res) => {
+  const survey = await Survey.findById(req.params.id).lean();
+  if (!survey) throw new AppError('Survey not found', 404);
+  res.json(survey);
+}));
 
 module.exports = router;

--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ const questionsRouter = require('./routes/questions');
 const responsesRouter = require('./routes/responses');
 const adminRouter = require('./routes/admin');
 const surveysRouter = require('./routes/surveys');
+const errorHandler = require('./middlewares/errorHandler');
 
 const app = express();
 const PORT = process.env.PORT || 5000;
@@ -28,6 +29,7 @@ app.use('/api', questionsRouter);
 app.use('/api', responsesRouter);
 app.use('/api', surveysRouter);
 app.use('/api/admin', adminRouter);
+app.use(errorHandler);
 
 const CLIENT_BUILD_PATH = path.join(__dirname, 'client', 'dist');
 app.use(express.static(CLIENT_BUILD_PATH));

--- a/utils/AppError.js
+++ b/utils/AppError.js
@@ -1,0 +1,8 @@
+class AppError extends Error {
+  constructor(message, statusCode = 400) {
+    super(message);
+    this.statusCode = statusCode;
+  }
+}
+
+module.exports = AppError;


### PR DESCRIPTION
## Summary
- add asyncHandler middleware for wrapping async route handlers
- add global errorHandler middleware for consistent JSON error responses
- create AppError utility for custom status codes
- refactor survey routes and controllers to use asyncHandler
- wire errorHandler into Express server

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_b_6868b9e0d06c8332a193f2a05d804df3